### PR TITLE
DataSet::toArray() method added

### DIFF
--- a/Tests/DataSetTest.php
+++ b/Tests/DataSetTest.php
@@ -166,11 +166,6 @@ class DataSetTest extends \PHPUnit_Framework_TestCase
 	 */
 	public function testGetObjectsKeys()
 	{
-		if (version_compare(PHP_VERSION, '5.4.0', '<='))
-		{
-			$this->markTestIncomplete('JsonSerializable is not supported in PHP 5.3');
-		}
-
 		$instance = new Data\DataSet(
 			array(
 				'key1' => new Data\DataObject(array('foo' => 'var', 'bar' => 'var', 'baz' => 'var')),
@@ -200,11 +195,6 @@ class DataSetTest extends \PHPUnit_Framework_TestCase
 	 */
 	public function testToArray()
 	{
-		if (version_compare(PHP_VERSION, '5.4.0', '<='))
-		{
-			$this->markTestIncomplete('JsonSerializable is not supported in PHP 5.3');
-		}
-
 		$instance = new Data\DataSet(
 			array(
 				'key1' => new Data\DataObject(array('date1' => '2014-08-29', 'date2' => '2014-09-16')),

--- a/Tests/DataSetTest.php
+++ b/Tests/DataSetTest.php
@@ -164,8 +164,47 @@ class DataSetTest extends \PHPUnit_Framework_TestCase
 	 * @covers  Joomla\Data\DataSet::toArray
 	 * @since   1.0
 	 */
+	public function testGetObjectsKeys()
+	{
+		if (version_compare(PHP_VERSION, '5.4.0', '<='))
+		{
+			$this->markTestIncomplete('JsonSerializable is not supported in PHP 5.3');
+		}
+
+		$instance = new Data\DataSet(
+			array(
+				'key1' => new Data\DataObject(array('foo' => 'var', 'bar' => 'var', 'baz' => 'var')),
+				'key2' => new Data\DataObject(array('foo' => 'var', 'quz' => 'var', 'baz' => 'var')),
+				'key3' => new Data\DataObject(array('foo' => 'var', 'bar' => 'var'))
+			)
+		);
+
+		$this->assertThat(
+			$instance->getObjectsKeys(),
+			$this->equalTo(array('foo','bar','baz','quz'))
+		);
+
+		$this->assertThat(
+			$instance->getObjectsKeys('common'),
+			$this->equalTo(array('foo'))
+		);
+	}
+
+	/**
+	 * Tests the Joomla\Data\DataSet::toArray method.
+	 *
+	 * @return  void
+	 *
+	 * @covers  Joomla\Data\DataSet::toArray
+	 * @since   1.0
+	 */
 	public function testToArray()
 	{
+		if (version_compare(PHP_VERSION, '5.4.0', '<='))
+		{
+			$this->markTestIncomplete('JsonSerializable is not supported in PHP 5.3');
+		}
+
 		$instance = new Data\DataSet(
 			array(
 				'key1' => new Data\DataObject(array('date1' => '2014-08-29', 'date2' => '2014-09-16')),

--- a/Tests/DataSetTest.php
+++ b/Tests/DataSetTest.php
@@ -157,6 +157,68 @@ class DataSetTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
+	 * Tests the Joomla\Data\DataSet::toArray method.
+	 *
+	 * @return  void
+	 *
+	 * @covers  Joomla\Data\DataSet::toArray
+	 * @since   1.0
+	 */
+	public function testToArray()
+	{
+		$instance = new Data\DataSet(
+			array(
+				'key1' => new Data\DataObject(array('date1' => '2014-08-29', 'date2' => '2014-09-16')),
+				'key2' => new Data\DataObject(array('date1' => '2014-07-06', 'date2' => '2014-08-05')),
+				'key3' => new Data\DataObject(array('date1' => '2013-12-01', 'date2' => '2014-06-26')),
+				'key4' => new Data\DataObject(array('date1' => '2013-10-07')),
+				'key5' => new Data\DataObject(array('date2' => '2010-04-01'))
+			)
+		);
+
+		$array1 = $instance->toArray(true);
+		$expect1 = array(
+			'key1' => array('date1' => '2014-08-29', 'date2' => '2014-09-16'),
+			'key2' => array('date1' => '2014-07-06', 'date2' => '2014-08-05'),
+			'key3' => array('date1' => '2013-12-01', 'date2' => '2014-06-26'),
+			'key4' => array('date1' => '2013-10-07', 'date2' => null),
+			'key5' => array('date1' => null, 'date2' => '2010-04-01')
+		);
+
+		$array2 = $instance->toArray(false, 'date1');
+		$expect2 = array(
+			array('2014-08-29'),
+			array('2014-07-06'),
+			array('2013-12-01'),
+			array('2013-10-07'),
+			array(null)
+		);
+
+		$array3 = $instance->toArray(false);
+		$expect3 = array(
+			array('2014-08-29','2014-09-16'),
+			array('2014-07-06','2014-08-05'),
+			array('2013-12-01','2014-06-26'),
+			array('2013-10-07', null),
+			array(null, '2010-04-01')
+		);
+
+		$array4 = $instance->toArray(true, 'date2');
+		$expect4 = array(
+			'key1' => array('date2' => '2014-09-16'),
+			'key2' => array('date2' => '2014-08-05'),
+			'key3' => array('date2' => '2014-06-26'),
+			'key4' => array('date2' => null),
+			'key5' => array('date2' => '2010-04-01')
+		);
+
+		$this->assertEquals($expect1, $array1, 'Method should return uniform arrays');
+		$this->assertEquals($expect2, $array2);
+		$this->assertEquals($expect3, $array3);
+		$this->assertEquals($expect4, $array4);
+	}
+
+	/**
 	 * Tests the Joomla\Data\DataSet::count method.
 	 *
 	 * @return  void

--- a/src/DataSet.php
+++ b/src/DataSet.php
@@ -187,6 +187,42 @@ class DataSet implements DumpableInterface, \ArrayAccess, \Countable, \Iterator
 	}
 
 	/**
+	 * Gets an array of keys, existing in objects
+	 * 
+	 * @param   string  $type  Selection type 'all' or 'common'
+	 * 
+	 * @throws  Exception
+	 * 
+	 * @return  array   Array of keys
+	 */
+
+	public function getObjectsKeys($type = 'all')
+	{
+		$keys = array();
+
+		if ($type == 'all')
+		{
+			$function = 'array_merge';
+		}
+		elseif ($type == 'common')
+		{
+			$function = 'array_intersect_key';
+		}
+		else
+		{
+			throw new \Exception("Unknown selection type: " . $type);
+		}
+
+		foreach ($this->objects as $object)
+		{
+			$object_vars = json_decode(json_encode($object), true);
+			$keys = $function($keys, $object_vars);
+		}
+
+		return array_keys($keys);
+	}
+
+	/**
 	 * Gets all objects as an array
 	 *
 	 * @param   boolean  $associative  Option to set return mode: associative or numeric array.

--- a/src/DataSet.php
+++ b/src/DataSet.php
@@ -236,7 +236,11 @@ class DataSet implements DumpableInterface, \ArrayAccess, \Countable, \Iterator
 	{
 		$keys = func_get_args();
 		$associative = array_shift($keys);
-		$full = (count($keys) == 0);
+
+		if (empty($keys))
+		{
+			$keys = $this->getObjectsKeys();
+		}
 
 		$return = array();
 
@@ -244,26 +248,19 @@ class DataSet implements DumpableInterface, \ArrayAccess, \Countable, \Iterator
 
 		foreach ($this->objects as $key => $object)
 		{
-			$return_object = array();
+			$array_item = array();
 
 			$key = ($associative) ? $key : $i++;
 
-			if (!$full)
-			{
-				$j = 0;
+			$j = 0;
 
-				foreach ($keys as $property)
-				{
-					$property_key = ($associative) ? $property : $j++;
-					$return_object[$property_key] = (isset($object->$property)) ? $object->$property : null;
-				}
-			}
-			else
+			foreach ($keys as $property)
 			{
-				$return_object = ($associative) ? (array) $object : array_values((array) $object);
+				$property_key = ($associative) ? $property : $j++;
+				$array_item[$property_key] = (isset($object->$property)) ? $object->$property : null;
 			}
 
-			$return[$key] = $return_object;
+			$return[$key] = $array_item;
 		}
 
 		return $return;

--- a/src/DataSet.php
+++ b/src/DataSet.php
@@ -213,10 +213,22 @@ class DataSet implements DumpableInterface, \ArrayAccess, \Countable, \Iterator
 			throw new \Exception("Unknown selection type: " . $type);
 		}
 
-		foreach ($this->objects as $object)
+		if (version_compare(PHP_VERSION, '5.4.0', '<'))
 		{
-			$object_vars = json_decode(json_encode($object), true);
-			$keys = (is_null($keys)) ? $object_vars : $function($keys, $object_vars);
+			foreach ($this->objects as $object)
+			{
+				$object_vars = json_decode(json_encode($object->jsonSerialize()), true);
+				$keys = (is_null($keys)) ? $object_vars : $function($keys, $object_vars);
+			}
+		}
+		else
+		{
+			foreach ($this->objects as $object)
+			{
+				
+				$object_vars = json_decode(json_encode($object), true);
+				$keys = (is_null($keys)) ? $object_vars : $function($keys, $object_vars);
+			}
 		}
 
 		return array_keys($keys);

--- a/src/DataSet.php
+++ b/src/DataSet.php
@@ -186,52 +186,52 @@ class DataSet implements DumpableInterface, \ArrayAccess, \Countable, \Iterator
 		}
 	}
 
-  /**
-   * Gets all objects as an array
-   *
-   * @param   boolean  $associative  Option to set return mode: associative or numeric array.
-   * @param   string   $k,...        Unlimited optional property names to extract from objects.
-   * 
-   * @return  array    Returns an array according to defined options.
-   *
-   * @since   1.0
-   */
-  public function toArray($associative = true, $k = NULL)
-  {
-    $keys = func_get_args();
-    
-    $associative = array_shift($keys);
-    
-    $full = (count($keys)==0);
-    
-    $return = array();
-    
-    $i = 0;
-    foreach ($this->objects as $key => $object)
-    {
-      $return_object = array();
-      
-      $key = ($associative) ? $key : $i++;
-      
-      if (!$full)
-      {
-        $j = 0;
-        foreach ($keys as $property)
-        {
-          $property_key = ($associative) ? $property : $j++;
-          $return_object[$property_key] = (isset($object->$property)) ? $object->$property : null;
-        }
-      }
-      else
-      {
-        $return_object = ($associative) ? (array) $object : array_values((array) $object);
-      }
-      
-      $return[$key] = $return_object;
-    }
-    return $return;
-    
-  }
+	/**
+	 * Gets all objects as an array
+	 *
+	 * @param   boolean  $associative  Option to set return mode: associative or numeric array.
+	 * @param   string   $k            Unlimited optional property names to extract from objects.
+	 * 
+	 * @return  array    Returns an array according to defined options.
+	 *
+	 * @since   1.0
+	 */
+	public function toArray($associative = true, $k = null)
+	{
+		$keys = func_get_args();
+		$associative = array_shift($keys);
+		$full = (count($keys) == 0);
+
+		$return = array();
+
+		$i = 0;
+
+		foreach ($this->objects as $key => $object)
+		{
+			$return_object = array();
+
+			$key = ($associative) ? $key : $i++;
+
+			if (!$full)
+			{
+				$j = 0;
+
+				foreach ($keys as $property)
+				{
+					$property_key = ($associative) ? $property : $j++;
+					$return_object[$property_key] = (isset($object->$property)) ? $object->$property : null;
+				}
+			}
+			else
+			{
+				$return_object = ($associative) ? (array) $object : array_values((array) $object);
+			}
+
+			$return[$key] = $return_object;
+		}
+
+		return $return;
+	}
 
 	/**
 	 * Gets the number of data objects in the set.

--- a/src/DataSet.php
+++ b/src/DataSet.php
@@ -186,6 +186,53 @@ class DataSet implements DumpableInterface, \ArrayAccess, \Countable, \Iterator
 		}
 	}
 
+  /**
+   * Gets all objects as an array
+   *
+   * @param   boolean  $associative  Option to set return mode: associative or numeric array.
+   * @param   string   $k,...        Unlimited optional property names to extract from objects.
+   * 
+   * @return  array    Returns an array according to defined options.
+   *
+   * @since   1.0
+   */
+  public function toArray($associative = true, $k = NULL)
+  {
+    $keys = func_get_args();
+    
+    $associative = array_shift($keys);
+    
+    $full = (count($keys)==0);
+    
+    $return = array();
+    
+    $i = 0;
+    foreach ($this->objects as $key => $object)
+    {
+      $return_object = array();
+      
+      $key = ($associative) ? $key : $i++;
+      
+      if (!$full)
+      {
+        $j = 0;
+        foreach ($keys as $property)
+        {
+          $property_key = ($associative) ? $property : $j++;
+          $return_object[$property_key] = (isset($object->$property)) ? $object->$property : null;
+        }
+      }
+      else
+      {
+        $return_object = ($associative) ? (array) $object : array_values((array) $object);
+      }
+      
+      $return[$key] = $return_object;
+    }
+    return $return;
+    
+  }
+
 	/**
 	 * Gets the number of data objects in the set.
 	 *

--- a/src/DataSet.php
+++ b/src/DataSet.php
@@ -198,7 +198,7 @@ class DataSet implements DumpableInterface, \ArrayAccess, \Countable, \Iterator
 
 	public function getObjectsKeys($type = 'all')
 	{
-		$keys = array();
+		$keys = null;
 
 		if ($type == 'all')
 		{
@@ -216,7 +216,7 @@ class DataSet implements DumpableInterface, \ArrayAccess, \Countable, \Iterator
 		foreach ($this->objects as $object)
 		{
 			$object_vars = json_decode(json_encode($object), true);
-			$keys = $function($keys, $object_vars);
+			$keys = (is_null($keys)) ? $object_vars : $function($keys, $object_vars);
 		}
 
 		return array_keys($keys);


### PR DESCRIPTION
A method to extract data from DataSet as custom array.
Example:

    $set = new DataSet(array(
        new DataObject(array('date'=>'1990', 'projects'=>5, 'employees'=>50)),
        new DataObject(array('date'=>'2000', 'projects'=>12, 'employees'=>140)),
        new DataObject(array('date'=>'2010', 'projects'=>11, 'employees'=>110))
    ));
    echo json_encode($set->toArray(false, 'date', 'projects'));
    echo json_encode($set->toArray());

In first case the return will be `[["1990",5],["2000",12],["2010",11]]`
In second case a full dump of DataSet in json format.

The method is very usefull when data from a set is to be inserted into database or extracted in custom format.