### PR TITLE
Use Registry 2.0-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "php": ">=5.3.10",
         "joomla/compat": "~1.0",
-        "joomla/registry": "~1.0"
+        "joomla/registry": "2.0@dev"
     },
     "require-dev": {
         "joomla/test": "~1.0",


### PR DESCRIPTION
To be consistent with joomla-framework/form@b5c9eab4b41e5e4161fa77e810246990f2d48377.
My composer depencies tree is broken. It had to choose between Registry 1.0 or Registry 2.0@dev.