### PR TITLE
Data package can take registry v1 or v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "php": "^5.5.9|~7.0",
         "joomla/compat": "~1.0",
-        "joomla/registry": "2.0.*@dev"
+        "joomla/registry": "~1.0|2.0.*@dev"
     },
     "require-dev": {
         "joomla/test": "~1.0",


### PR DESCRIPTION
Allows the data package to accept an instance of v1 or v2 of the registry package.

Given the only use of registry is this https://github.com/joomla-framework/data/blob/master/src/DataObject.php#L262-L266 really not sure we even should be depending on it. But *shrug*