### PR TITLE
Use `@link` over `@see` and move Link to https

### DIFF
--- a/Tests/DataObjectTest.php
+++ b/Tests/DataObjectTest.php
@@ -449,7 +449,7 @@ class DataObjectTest extends TestCase
 	 * @return  void
 	 *
 	 * @covers  Joomla\Data\DataObject::setProperty
-	 * @see     http://us3.php.net/manual/en/language.types.array.php#language.types.array.casting
+	 * @link    https://secure.php.net/manual/en/language.types.array.php#language.types.array.casting
 	 * @since   1.0
 	 */
 	public function testSetPropertySkipsPropertyWithNullBytes()


### PR DESCRIPTION
### Summary of Changes

Use `@link` over `@see` and move PHP Links to https

### Testing Instructions

Review

### Documentation Changes Required

None