### PR TITLE
Fixes DataObject::jsonSerialize method documented return type to be an object.

### DIFF
--- a/src/DataObject.php
+++ b/src/DataObject.php
@@ -214,7 +214,7 @@ class DataObject implements DumpableInterface, \IteratorAggregate, \JsonSerializ
 	/**
 	 * Gets the data properties in a form that can be serialised to JSON format.
 	 *
-	 * @return  string
+	 * @return  \stdClass
 	 *
 	 * @since   1.0
 	 */


### PR DESCRIPTION
Pull Request for Issue #17

Just correcting the documentation

### Summary of Changes
Fixes DataObject::jsonSerialize method documented return type to be an object.

### Testing Instructions
Normal

### Documentation Changes Required
None
