### PR TITLE
[PHP8.4] Deprecate implicitly nullable parameter types

### DIFF
--- a/Tests/DataObjectTest.php
+++ b/Tests/DataObjectTest.php
@@ -8,10 +8,8 @@
 namespace Joomla\Data\Tests;
 
 use Joomla\Data\DataObject;
-use Joomla\Data\Tests\Stubs\Buran;
 use Joomla\Data\Tests\Stubs\Capitaliser;
 use Joomla\Registry\Registry;
-use Joomla\Test\TestHelper;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/src/DataObject.php
+++ b/src/DataObject.php
@@ -166,7 +166,7 @@ class DataObject implements DumpableInterface, \IteratorAggregate, \JsonSerializ
      *
      * @since   1.0
      */
-    public function dump($depth = 3, \SplObjectStorage $dumped = null)
+    public function dump($depth = 3, ?\SplObjectStorage $dumped = null)
     {
         // Check if we should initialise the recursion tracker.
         if ($dumped === null) {

--- a/src/DataSet.php
+++ b/src/DataSet.php
@@ -301,7 +301,7 @@ class DataSet implements DumpableInterface, \ArrayAccess, \Countable, \Iterator
      * @see     DataObject::dump()
      * @since   1.0
      */
-    public function dump($depth = 3, \SplObjectStorage $dumped = null)
+    public function dump($depth = 3, ?\SplObjectStorage $dumped = null)
     {
         // Check if we should initialise the recursion tracker.
         if ($dumped === null) {

--- a/src/DumpableInterface.php
+++ b/src/DumpableInterface.php
@@ -28,5 +28,5 @@ interface DumpableInterface
      *
      * @since   1.0
      */
-    public function dump($depth = 3, \SplObjectStorage $dumped = null);
+    public function dump($depth = 3, ?\SplObjectStorage $dumped = null);
 }


### PR DESCRIPTION
### Summary of Changes

updates for [Deprecate implicitly nullable parameter types](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types)

### Testing Instructions

code review

### Documentation Changes Required

no