### PR TITLE
Updating phpstan to 2.0

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -77,7 +77,7 @@ local pipeline(name, phpversion, params) = {
                 depends: [ "composer" ],
                 failure: "ignore",
                 commands: [
-                    "vendor/bin/phpstan analyse src",
+                    "./vendor/bin/phpstan",
                 ]
             },
             {

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -104,4 +104,5 @@ local pipeline(name, phpversion, params) = {
     pipeline("8.1", "8.1", "--prefer-stable"),
     pipeline("8.2", "8.2", "--prefer-stable"),
     pipeline("8.3", "8.3", "--prefer-stable"),
+    pipeline("8.4", "8.4", "--prefer-stable"),
 ]

--- a/.drone.yml
+++ b/.drone.yml
@@ -24,7 +24,7 @@ steps:
   image: joomlaprojects/docker-images:php8.1-ast
   name: phan
 - commands:
-  - vendor/bin/phpstan analyse src
+  - ./vendor/bin/phpstan
   depends:
   - composer
   failure: ignore

--- a/.drone.yml
+++ b/.drone.yml
@@ -129,7 +129,28 @@ volumes:
     path: /tmp/composer-cache
   name: composer-cache
 ---
+kind: pipeline
+name: PHP 8.4
+steps:
+- commands:
+  - php -v
+  - composer update --prefer-stable
+  image: joomlaprojects/docker-images:php8.4
+  name: composer
+  volumes:
+  - name: composer-cache
+    path: /tmp/composer-cache
+- commands:
+  - vendor/bin/phpunit
+  failure: ignore
+  image: joomlaprojects/docker-images:php8.4
+  name: PHPUnit
+volumes:
+- host:
+    path: /tmp/composer-cache
+  name: composer-cache
+---
 kind: signature
-hmac: 743684447aabb4aa6e8931a70573c8ad4a88a6b577058077d16720513c1026b0
+hmac: a1b1d2b4ab52d4c766a105f6646b477c92a9818dc6bfbf68cc1d352e7dc00f60
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -130,6 +130,6 @@ volumes:
   name: composer-cache
 ---
 kind: signature
-hmac: 19a9e9a39d7f06fd46a06050f4f5b64a3a92deecec28897bf40b70bafcf9fdde
+hmac: 743684447aabb4aa6e8931a70573c8ad4a88a6b577058077d16720513c1026b0
 
 ...

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         "joomla/test": "^3.0",
         "phpunit/phpunit": "^9.5.28",
         "squizlabs/php_codesniffer": "~3.7.2",
-        "phpstan/phpstan": "^1.10.7",
+        "phpstan/phpstan": "^2.0",
+        "phpstan/phpstan-deprecation-rules": "^2.0",
         "phan/phan": "^5.4.2"
     },
     "autoload": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,10 @@
+
+includes:
+	- vendor/phpstan/phpstan-deprecation-rules/rules.neon
+
+parameters:
+	level: 5
+	phpVersion: 80100
+	reportUnmatchedIgnoredErrors: false
+	paths:
+		- src


### PR DESCRIPTION
### Summary of Changes
This updates phpstan to version 2.0, adds a configuration file for phpstan and sets the level to 5, adds the deprecation plugin to it and changes the call in drone.

### Testing Instructions
Codereview
