### PR TITLE
[3.x] Fix unignorable phpstan errors

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11,21 +11,6 @@ parameters:
 			path: src/DataSet.php
 
 		-
-			message: "#^Method Joomla\\\\Data\\\\DataSet\\:\\:valid\\(\\) with return type void returns false but should not return anything\\.$#"
-			count: 1
-			path: src/DataSet.php
-
-		-
-			message: "#^Method Joomla\\\\Data\\\\DataSet\\:\\:valid\\(\\) with return type void returns true but should not return anything\\.$#"
-			count: 1
-			path: src/DataSet.php
-
-		-
-			message: "#^PHPDoc tag @return with type bool is incompatible with native type void\\.$#"
-			count: 1
-			path: src/DataSet.php
-
-		-
 			message: "#^Property Joomla\\\\Data\\\\DataSet\\:\\:\\$current \\(int\\) does not accept default value of type false\\.$#"
 			count: 1
 			path: src/DataSet.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11,6 +11,21 @@ parameters:
 			path: src/DataSet.php
 
 		-
+			message: "#^Method Joomla\\\\Data\\\\DataSet\\:\\:valid\\(\\) with return type void returns false but should not return anything\\.$#"
+			count: 1
+			path: src/DataSet.php
+
+		-
+			message: "#^Method Joomla\\\\Data\\\\DataSet\\:\\:valid\\(\\) with return type void returns true but should not return anything\\.$#"
+			count: 1
+			path: src/DataSet.php
+
+		-
+			message: "#^PHPDoc tag @return with type bool is incompatible with native type void\\.$#"
+			count: 1
+			path: src/DataSet.php
+
+		-
 			message: "#^Property Joomla\\\\Data\\\\DataSet\\:\\:\\$current \\(int\\) does not accept default value of type false\\.$#"
 			count: 1
 			path: src/DataSet.php

--- a/src/DataObject.php
+++ b/src/DataObject.php
@@ -198,7 +198,7 @@ class DataObject implements DumpableInterface, \IteratorAggregate, \JsonSerializ
      * @see     IteratorAggregate::getIterator()
      * @since   1.0
      */
-    public function getIterator()
+    public function getIterator(): \ArrayIterator
     {
         return new \ArrayIterator($this->dump(0));
     }
@@ -206,11 +206,11 @@ class DataObject implements DumpableInterface, \IteratorAggregate, \JsonSerializ
     /**
      * Gets the data properties in a form that can be serialised to JSON format.
      *
-     * @return  mixed
+     * @return  \stdClass
      *
      * @since   1.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): \stdClass
     {
         return $this->dump();
     }
@@ -304,7 +304,7 @@ class DataObject implements DumpableInterface, \IteratorAggregate, \JsonSerializ
      *
      * @since   1.0
      */
-    public function count()
+    public function count(): int
     {
         return \count($this->properties);
     }

--- a/src/DataSet.php
+++ b/src/DataSet.php
@@ -256,7 +256,7 @@ class DataSet implements DumpableInterface, \ArrayAccess, \Countable, \Iterator
      *
      * @since   1.0
      */
-    public function count()
+    public function count(): int
     {
         return \count($this->objects);
     }
@@ -268,7 +268,7 @@ class DataSet implements DumpableInterface, \ArrayAccess, \Countable, \Iterator
      *
      * @since   1.0
      */
-    public function clear()
+    public function clear(): DataSet
     {
         $this->objects = [];
         $this->rewind();
@@ -279,11 +279,11 @@ class DataSet implements DumpableInterface, \ArrayAccess, \Countable, \Iterator
     /**
      * Get the current data object in the set.
      *
-     * @return  DataObject|false  The current object, or false if the array is empty or the pointer is beyond the end of the elements.
+     * @return  DataObject|bool  The current object, or false if the array is empty or the pointer is beyond the end of the elements.
      *
      * @since   1.0
      */
-    public function current()
+    public function current(): DataObject|bool
     {
         return is_scalar($this->current) ? $this->objects[$this->current] : false;
     }
@@ -350,11 +350,11 @@ class DataSet implements DumpableInterface, \ArrayAccess, \Countable, \Iterator
     /**
      * Gets the key of the current object in the iterator.
      *
-     * @return  integer|false  The object key on success; false on failure.
+     * @return  int|bool|null  The object key on success; false on failure.
      *
      * @since   1.0
      */
-    public function key()
+    public function key(): int|bool|null
     {
         return $this->current;
     }
@@ -397,7 +397,7 @@ class DataSet implements DumpableInterface, \ArrayAccess, \Countable, \Iterator
      *
      * @since   1.0
      */
-    public function next()
+    public function next(): void
     {
         // Get the object offsets.
         $keys = $this->keys();
@@ -430,7 +430,7 @@ class DataSet implements DumpableInterface, \ArrayAccess, \Countable, \Iterator
      *
      * @since   1.0
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->objects[$offset]);
     }
@@ -444,7 +444,7 @@ class DataSet implements DumpableInterface, \ArrayAccess, \Countable, \Iterator
      *
      * @since   1.0
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): DataObject|null
     {
         return $this->objects[$offset] ?? null;
     }
@@ -460,7 +460,7 @@ class DataSet implements DumpableInterface, \ArrayAccess, \Countable, \Iterator
      * @since   1.0
      * @throws  \InvalidArgumentException if an object is not an instance of DataObject.
      */
-    public function offsetSet($offset, $object)
+    public function offsetSet($offset, $object): void
     {
         if (!($object instanceof DataObject)) {
             throw new \InvalidArgumentException(
@@ -489,7 +489,7 @@ class DataSet implements DumpableInterface, \ArrayAccess, \Countable, \Iterator
      *
      * @since   1.0
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         if (!isset($this[$offset])) {
             // Do nothing if the offset does not exist.
@@ -522,7 +522,7 @@ class DataSet implements DumpableInterface, \ArrayAccess, \Countable, \Iterator
      *
      * @since   1.0
      */
-    public function rewind()
+    public function rewind(): void
     {
         // Set the current position to the first object.
         if (empty($this->objects)) {
@@ -540,7 +540,7 @@ class DataSet implements DumpableInterface, \ArrayAccess, \Countable, \Iterator
      *
      * @since   1.0
      */
-    public function valid()
+    public function valid(): void
     {
         // Check the current position.
         if (!is_scalar($this->current) || !isset($this->objects[$this->current])) {

--- a/src/DataSet.php
+++ b/src/DataSet.php
@@ -540,7 +540,7 @@ class DataSet implements DumpableInterface, \ArrayAccess, \Countable, \Iterator
      *
      * @since   1.0
      */
-    public function valid(): void
+    public function valid(): bool
     {
         // Check the current position.
         if (!is_scalar($this->current) || !isset($this->objects[$this->current])) {


### PR DESCRIPTION
Alternative to PR #29 .

### Summary of Changes

Fix unignorable PHPStan errors.

Another way to fix these errors would be PR #29 .

For the remaining, ignorable errors, the baseline was backported from 4.x-dev with commit https://github.com/joomla-framework/data/commit/9d7c5c82d84043fe45d37ba46ee75037d3ef5b95 and adapted to 3.x-dev with commit https://github.com/joomla-framework/data/commit/f92ec436dab20c6944814e42ed06e2dcfc9e3d81 .

@Hackwar @rdeutz Can we do it that way to make phpstan pass in 3.x-dev? Or are the method singature changes b/c breaks?