### PR TITLE
[3.x] Add ReturnTypeWillChange attribute to methods where return types will be fixed in 4.x-dev

### DIFF
--- a/src/DataObject.php
+++ b/src/DataObject.php
@@ -198,6 +198,7 @@ class DataObject implements DumpableInterface, \IteratorAggregate, \JsonSerializ
      * @see     IteratorAggregate::getIterator()
      * @since   1.0
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new \ArrayIterator($this->dump(0));
@@ -210,6 +211,7 @@ class DataObject implements DumpableInterface, \IteratorAggregate, \JsonSerializ
      *
      * @since   1.0
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->dump();
@@ -304,6 +306,7 @@ class DataObject implements DumpableInterface, \IteratorAggregate, \JsonSerializ
      *
      * @since   1.0
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return \count($this->properties);

--- a/src/DataSet.php
+++ b/src/DataSet.php
@@ -256,6 +256,7 @@ class DataSet implements DumpableInterface, \ArrayAccess, \Countable, \Iterator
      *
      * @since   1.0
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return \count($this->objects);
@@ -283,6 +284,7 @@ class DataSet implements DumpableInterface, \ArrayAccess, \Countable, \Iterator
      *
      * @since   1.0
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return is_scalar($this->current) ? $this->objects[$this->current] : false;
@@ -354,6 +356,7 @@ class DataSet implements DumpableInterface, \ArrayAccess, \Countable, \Iterator
      *
      * @since   1.0
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->current;
@@ -397,6 +400,7 @@ class DataSet implements DumpableInterface, \ArrayAccess, \Countable, \Iterator
      *
      * @since   1.0
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         // Get the object offsets.
@@ -430,6 +434,7 @@ class DataSet implements DumpableInterface, \ArrayAccess, \Countable, \Iterator
      *
      * @since   1.0
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->objects[$offset]);
@@ -444,6 +449,7 @@ class DataSet implements DumpableInterface, \ArrayAccess, \Countable, \Iterator
      *
      * @since   1.0
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->objects[$offset] ?? null;
@@ -460,6 +466,7 @@ class DataSet implements DumpableInterface, \ArrayAccess, \Countable, \Iterator
      * @since   1.0
      * @throws  \InvalidArgumentException if an object is not an instance of DataObject.
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $object)
     {
         if (!($object instanceof DataObject)) {
@@ -489,6 +496,7 @@ class DataSet implements DumpableInterface, \ArrayAccess, \Countable, \Iterator
      *
      * @since   1.0
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         if (!isset($this[$offset])) {
@@ -522,6 +530,7 @@ class DataSet implements DumpableInterface, \ArrayAccess, \Countable, \Iterator
      *
      * @since   1.0
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         // Set the current position to the first object.
@@ -540,6 +549,7 @@ class DataSet implements DumpableInterface, \ArrayAccess, \Countable, \Iterator
      *
      * @since   1.0
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         // Check the current position.


### PR DESCRIPTION
Alternative to PR #28 .

Fix unignorable PHPStan errors in 3.x-dev by adding the ReturnTypeWillChange attribute.

The attribute will be removed again (or not be added) in 4.x-dev.

Another way to fix the unignorable PHPStan errors would be PR #28 .